### PR TITLE
Allow global statusline if users have set it

### DIFF
--- a/plugin/skyline.vim
+++ b/plugin/skyline.vim
@@ -12,7 +12,9 @@ let g:loaded_skyline = 1
 let s:save_cpoptions = &cpoptions
 set cpoptions&vim
 
-set laststatus=2
+if &laststatus != 3
+    set laststatus=2
+endif
 
 " === User configuration variables ===
 " TODO: Changed skyline_gitbranch -> skyline_fugitive.


### PR DESCRIPTION
A neovim feature allows Global Status Lines via `set laststatus=3`. Currently, the plugin forces `set laststatus=2`, which prevents the use of the global statusline feature, as the plugin will override the user config.

This can be fixed by making sure `laststatus` is not equal to `3` before setting it to `2`. This ensures that if the user sets a global statusline, it will not be overriden.