### PR TITLE
Fix use of deprecated Fugitive function

### DIFF
--- a/autoload/skyline/fugitive.vim
+++ b/autoload/skyline/fugitive.vim
@@ -1,6 +1,6 @@
 function! skyline#fugitive#branch() abort
     if exists('g:loaded_fugitive')
-        let l:branch = fugitive#head()
+        let l:branch = FugitiveHead()
         return l:branch !=# '' ? ' ' . branch : ''
     endif
     return ''


### PR DESCRIPTION
https://github.com/tpope/vim-fugitive/commit/b81c59bd6adb2a1aac7d3865eb4ee0f6e51eb29c deprecates the use of `fugitive#head()`, so using skyline now causes ugly errors to be reported.

This change fixes it.