### PR TITLE
fix: absolute path relative from CWD

### DIFF
--- a/autoload/skyline/base.vim
+++ b/autoload/skyline/base.vim
@@ -1,5 +1,5 @@
 function! skyline#base#directory() abort
-    let l:directory = expand('%:h')
+    let l:directory = expand('%:p:.:h')
     if winwidth(0) <= 80
         let l:directory = pathshorten(l:directory)
     endif

--- a/plugin/skyline.vim
+++ b/plugin/skyline.vim
@@ -137,7 +137,7 @@ function! InactiveStatus()
     let l:statusline='%#StatusLineNC#'
 
     " === File path ===
-    let path_options = [ ' %t', ' %F' ]
+    let path_options = [ ' %t', ' %{skyline#base#directory()}%t' ]
     let statusline.=path_options[g:skyline_path]
 
     " === Modified flag [+] ===


### PR DESCRIPTION
Fixes what I would guess was error, where file path would not be
absolute relative from CWD after changing files wihtin project (from
netrw or other file browser). Also show same path on inactive buffers.